### PR TITLE
Add missing return

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,8 @@ module.exports = function (cb) {
 					code: res.codename
 				});
 			});
+
+			return;
 		}
 
 		stdout = stdout.split('\n');


### PR DESCRIPTION
If `lsb_release` doesn't exist, we'll end up calling the callback with bogus data from stdout then calling callback again with real data