### PR TITLE
Handle distros that don't have a version number

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,13 @@
-'use strict';
 const execa = require('execa');
-const getos = require('getos');
 const pify = require('pify');
+const getos = pify(require('getos'));
 
 module.exports = () => {
 	if (process.platform !== 'linux') {
 		return Promise.reject(new Error('Only Linux systems are supported'));
 	}
 
-	return execa('lsb_release', ['-a', '--short']).then(res => {
+	return execa('lsb_release', ['-a', '--short']).then((res) => {
 		const stdout = res.stdout.split('\n');
 
 		return {
@@ -18,7 +17,7 @@ module.exports = () => {
 			code: stdout[3]
 		};
 	}).catch(() => {
-		return pify(getos)(res => {
+		return getos().then((res) => {
 			return {
 				os: res.dist,
 				name: `${res.dist} ${res.release}`,

--- a/index.js
+++ b/index.js
@@ -19,10 +19,10 @@ module.exports = () => {
 	}).catch(() => {
 		return getos().then((res) => {
 			return {
-				os: res.dist,
-				name: `${res.dist} ${res.release}`,
-				release: res.release,
-				code: res.codename
+				os: res.dist || '',
+				name: `${res.dist || ''} ${res.release || ''}`,
+				release: res.release || '',
+				code: res.codename || ''
 			};
 		});
 	});


### PR DESCRIPTION
Some distros like Arch Linux, don't have a concept of a "version number" - don't dump the word `undefined` into distro names - stacked on top of the previous PR so that we don't get weird merges